### PR TITLE
build: update supported python versions to include 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install pre-commit hook:
 Test:
 
     make test   # for current environment
-    make tox    # for Python 3.9 and Python 3.10
+    make tox    # for Python 3.10, Python 3.11, Python 3.12
 
 Build:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ authors = [
 description = "Example Package"
 readme = "README.md"
 license = { file="LICENSE.txt" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py39,py310
+envlist = py310,py311,py312
 isolated_build = True
 
 [gh]
 python =
-    3.9 = py39, type
-    3.10 = py310    
+    3.10 = py310
+    3.11 = py311
+    3.12 = py312


### PR DESCRIPTION
close #38

* support the 3 most recent python releases: 3.10, 3.11, 3.12