### PR TITLE
switch Makefile to zsh and require zsh installation for developers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: zsh
+        version: 1.0
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,6 +49,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: zsh
+        version: 1.0
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -94,6 +99,11 @@ jobs:
         echo "::endgroup::"
 
     - uses: actions/checkout@v3
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: zsh
+        version: 1.0
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@
 .PRECIOUS:
 .SUFFIXES:
 
-HAVE_ZSH := $(shell command -v zsh >/dev/null 2>&1 && echo "yes" || echo "no")
-
 ifeq ("","$(shell command -v zsh)")
 $(error "zsh not found; you must install zsh first")
 endif

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,13 @@
 .PRECIOUS:
 .SUFFIXES:
 
-SHELL:=/bin/bash -e -o pipefail #-O globstar
+HAVE_ZSH := $(shell command -v zsh >/dev/null 2>&1 && echo "yes" || echo "no")
+
+ifeq ("","$(shell command -v zsh)")
+$(error "zsh not found; you must install zsh first")
+endif
+
+SHELL:=zsh -eu -o pipefail -o null_glob
 SELF:=$(firstword $(MAKEFILE_LIST))
 
 VE_DIR=venv
@@ -44,7 +50,7 @@ ${VE_DIR}:
 #=> develop: install package in develop mode
 .PHONY: develop
 develop:
-	pip install -e .[dev]
+	pip install -e ".[dev]"
 	pre-commit install
 
 #=> install: install package

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ develop:
 #=> install: install package
 .PHONY: install
 install:
-	pip install .
+	pip install "."
 
 #=> build: make sdist and wheel
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ To install from pypi: ```pip install biocommons.example```
 
 ## Developer Setup
 
+Developers must install zsh, which is required by the Makefile. zsh is included by default in MacOS, and is readily available on all modern Linux distributions.
+
 Setup like this:
 
     make devready
@@ -34,7 +36,7 @@ Install pre-commit hook:
 Test:
 
     make test   # for current environment
-    make tox    # for Python 3.10, Python 3.11, Python 3.12
+    make tox    # for all supported versions
 
 Build:
 


### PR DESCRIPTION
The biocommons Makefile had been using globstar for the clean* targets. This was much more reliable/less error prone/easier to read than find | xargs. However, Apple only installs bash v3 on Macs because of licensing concerns with bash v4. So, our options were:

- make Mac users install bash v4
- revert to find | xargs
- switch to zsh for the Makefile (users wouldn't have to switch their login shell)

Since this matter only is only relevant to developers, and because zsh is either already installed or easily installed on modern systems, the easiest move seems to be to require that developers install zsh. That's what this PR does.
