### PR TITLE
cicd: remove pyright/mypy stuff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,4 @@
 repos:
-- repo: local
-  hooks:
-    -  id: pyright
-       name: pyright
-       entry: pyright
-       language: system
-       types: [python]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,7 @@ dependencies = ["coloredlogs ~= 15.0", "pyyaml ~= 6.0"]
 dev = [
     "build ~= 0.8",
     "ipython ~= 8.4",
-    "mypy-extensions ~= 1.0",
     "pre-commit ~= 3.4",
-    "pyright~=1.1",
     "ruff == 0.4.4",
 ]
 tests = [
@@ -103,9 +101,6 @@ exclude_lines = [
     # Don't complain if non-runnable code isn't run:
     "if __name__ == .__main__.:",
 ]
-
-[tool.pyright]
-include = ["src", "tests"]
 
 [tool.ruff]
 src = ["src", "tests"]


### PR DESCRIPTION
@korikuzma, @theferrit32, and I felt like biocommons repos probably aren't ready for type checking -- there are still too many coverage holes -- and that other, nascent type checking libraries might be better soon. Our feeling is that this should be kept out of precommit until the repos have better type annotations and the tooling has stabilized more.