### PR TITLE
test: remove pytest-optional-tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dev = [
 ]
 tests = [
     "pytest-cov ~= 4.1",
-    "pytest-optional-tests",
     "pytest ~= 7.1",
     "vcrpy",
     "tox ~= 4.15",


### PR DESCRIPTION
Doesn't seem to be used anywhere yet, and the build on PyPI appears to be broken
